### PR TITLE
WIP egoStoppingVelocity and egoFollowingVelocity for decisionmaking

### DIFF
--- a/op_planner/include/op_planner/DecisionMaker.h
+++ b/op_planner/include/op_planner/DecisionMaker.h
@@ -84,8 +84,33 @@ protected:
 	//void UpdateCurrentLane(const double& search_distance);
 	bool SelectSafeTrajectory(const PlannerHNS::VehicleState& vehicleState);
 	BehaviorState GenerateBehaviorState(const VehicleState& vehicleState);
+
+	/**
+	 * Sets the trajectory velocity to the raw velocity. Returns the max velocity calculated with the ego stopping and following velocity.
+	 * Only without internal ECC.
+	 * @param beh
+	 * @param CurrStatus
+	 * @param dt
+	 */
 	double UpdateVelocityDirectlyToTrajectory(const BehaviorState& beh, const VehicleState& CurrStatus, const double& dt);
+
+	/**
+	 * Sets the trajectory velocity to a smoothed velocity. Returns the max velocity.
+	 * Used with internal ECC.
+	 * @param beh
+	 * @param CurrStatus
+	 * @param dt
+	 */
 	double UpdateVelocityDirectlyToTrajectorySmooth(BehaviorState& beh, const VehicleState& CurrStatus, const double& dt);
+
+	/**
+	 * Computes EgoFollowing and EgoStopping velocities. These values are used for decision making when the internal ECC is disabled.
+	 * Details : https://github.com/hatem-darweesh/common/pull/9
+	 * @param pValues Precalculated values
+	 * @param critical_long_front_distance
+	 */
+  void ComputeEgoFollowingAndStoppingVelocities(PreCalculatedConditions* pValues, double &critical_long_front_distance);
+
 	bool ReachEndOfGlobalPath(const double& min_distance, const int& iGlobalPathIndex);
 	bool TestForReplanningParams(const VehicleState& vehicleState);
 	void CheckForCurveZone(const VehicleState& vehicleState, double& curr_curve_cost, double& min_curve_cost);

--- a/op_planner/include/op_planner/RoadNetwork.h
+++ b/op_planner/include/op_planner/RoadNetwork.h
@@ -917,6 +917,8 @@ public:
 	double stopDistance;
 	double followVelocity;
 	double followDistance;
+        double egoStoppingVelocity;
+        double egoFollowingVelocity;
 	LIGHT_INDICATOR indicator;
 	bool bNewPlan;
 	int iTrajectory;
@@ -931,6 +933,8 @@ public:
 		stopDistance = 0;
 		followVelocity = 0;
 		followDistance = 0;
+                egoStoppingVelocity = 0.0;
+                egoFollowingVelocity = 0.0;
 		indicator  = INDICATOR_NONE;
 		bNewPlan = false;
 		iTrajectory = -1;
@@ -1106,6 +1110,7 @@ public:
 	//Following
 	double 				distanceToNext;
 	double				velocityOfNext;
+        double                          egoFollowingVelocity;
 	//-------------------------------------------//
 	//For Lane Change
 	int 				iPrevSafeLane;
@@ -1123,6 +1128,7 @@ public:
 	bool				bTargetLaneSafe;
 	//-------------------------------------------//
 	//Traffic Lights & Stop Sign
+        double                          egoStoppingVelocity;
 	int 				currentStopSignID;
 	int 				prevStopSignID;
 	int 				currentTrafficLightID;
@@ -1177,6 +1183,8 @@ public:
 		//distance to stop
 		distanceToNext = -1;
 		velocityOfNext = 0;
+                egoFollowingVelocity = 0.0;
+                egoStoppingVelocity = 0.0;
 		currentStopSignID = -1;
 		prevStopSignID = -1;
 		currentTrafficLightID = -1;

--- a/op_planner/include/op_planner/RoadNetwork.h
+++ b/op_planner/include/op_planner/RoadNetwork.h
@@ -917,8 +917,6 @@ public:
 	double stopDistance;
 	double followVelocity;
 	double followDistance;
-        double egoStoppingVelocity;
-        double egoFollowingVelocity;
 	LIGHT_INDICATOR indicator;
 	bool bNewPlan;
 	int iTrajectory;
@@ -933,8 +931,6 @@ public:
 		stopDistance = 0;
 		followVelocity = 0;
 		followDistance = 0;
-                egoStoppingVelocity = 0.0;
-                egoFollowingVelocity = 0.0;
 		indicator  = INDICATOR_NONE;
 		bNewPlan = false;
 		iTrajectory = -1;
@@ -1110,7 +1106,7 @@ public:
 	//Following
 	double 				distanceToNext;
 	double				velocityOfNext;
-        double                          egoFollowingVelocity;
+  double        egoFollowingVelocity;
 	//-------------------------------------------//
 	//For Lane Change
 	int 				iPrevSafeLane;
@@ -1128,7 +1124,7 @@ public:
 	bool				bTargetLaneSafe;
 	//-------------------------------------------//
 	//Traffic Lights & Stop Sign
-        double                          egoStoppingVelocity;
+  double      egoStoppingVelocity;
 	int 				currentStopSignID;
 	int 				prevStopSignID;
 	int 				currentTrafficLightID;
@@ -1183,8 +1179,8 @@ public:
 		//distance to stop
 		distanceToNext = -1;
 		velocityOfNext = 0;
-                egoFollowingVelocity = 0.0;
-                egoStoppingVelocity = 0.0;
+		egoFollowingVelocity = 0.0;
+		egoStoppingVelocity = 0.0;
 		currentStopSignID = -1;
 		prevStopSignID = -1;
 		currentTrafficLightID = -1;

--- a/op_planner/src/DecisionMaker.cpp
+++ b/op_planner/src/DecisionMaker.cpp
@@ -429,9 +429,16 @@ void DecisionMaker::InitBehaviorStates()
 	 * Block End ---------------------------------------------------------------------
 	 */
 
-     /**
-      * Computing Ego following velocity.
-      */
+  if (!m_bUseInternalACC) {
+    ComputeEgoFollowingAndStoppingVelocities(pValues, critical_long_front_distance);
+  }
+ }
+
+ void DecisionMaker::ComputeEgoFollowingAndStoppingVelocities(PreCalculatedConditions* pValues, double &critical_long_front_distance)
+ {
+   /**
+  * Computing Ego following velocity.
+  */
      if (!pValues->bFullyBlock)
      {
          pValues->egoFollowingVelocity = m_params.maxSpeed;
@@ -467,9 +474,6 @@ void DecisionMaker::InitBehaviorStates()
      }
      // clip ego STOPPING velocity between 0 and maxSpeed
      pValues->egoStoppingVelocity = std::min(std::max(pValues->egoStoppingVelocity, 0.0), m_params.maxSpeed);
-
-     std::cout << "STOPv: " << pValues->egoStoppingVelocity << "\n";
-     std::cout << "FOLLv: " << pValues->egoFollowingVelocity << "\n";
  }
 
  bool DecisionMaker::ReachEndOfGlobalPath(const double& min_distance, const int& iGlobalPathIndex)
@@ -634,8 +638,7 @@ void DecisionMaker::InitBehaviorStates()
  
  double DecisionMaker::UpdateVelocityDirectlyToTrajectory(const BehaviorState& beh, const VehicleState& CurrStatus, const double& dt)
  {
-
-	 PlannerHNS::PreCalculatedConditions *preCalcPrams = m_pCurrentBehaviorState->GetCalcParams();
+ PlannerHNS::PreCalculatedConditions *preCalcPrams = m_pCurrentBehaviorState->GetCalcParams();
 
 	if(!preCalcPrams || m_TotalPaths.size() == 0) return 0;
 
@@ -737,8 +740,7 @@ void DecisionMaker::InitBehaviorStates()
 		m_Path.at(i).v = desiredVelocity;
 	}
 
-	return max_velocity;
-
+	return std::min({max_velocity, preCalcPrams->egoStoppingVelocity, preCalcPrams->egoFollowingVelocity});
  }
 
  PlannerHNS::BehaviorState DecisionMaker::DoOneStep(


### PR DESCRIPTION
**This PR is part of the effort of merging back the changes made by the University of Tartu Self driving Lab.**

This is one of our main changes to OP logic. We have created two new pvalues : `egoStoppingVelocity` and `egoFollowingVelocity`.  These two values are **always** computed at each iteration.

- `egoStoppingVelocity` is the velocity required to stop at the next stopline. When a stopline gets close this values gets smaller. When no stopline it is `maxSpeed`.
- `egoFollowingVelocity` is the velocity to follow the closest object. When the rollout is not blocked it is `maxSpeed`.

### Scenarios : 
We say that `maxSpeed` = `11 m.s^-1` and `velocityOfNext` = `11 m.s^-1` 

- Driving at `maxSpeed`. No stopline, No obstacles.
  ![image](https://user-images.githubusercontent.com/22786578/120652305-54121680-c488-11eb-8c99-245ba62a3abe.png)
  All nominal.
  - `egoStoppingVelocity` = `maxSpeed`
  - `egoFollowingVelocity` = `maxSpeed`

- Driving at `maxSpeed`. Stopline approaching, No obstacles.
  ![image](https://user-images.githubusercontent.com/22786578/120652594-94719480-c488-11eb-9875-c449aa07e2cb.png)
  As the stopline is approaching `egoStoppingVelocity` decreases. 
  - `egoStoppingVelocity` = `5`
  - `egoFollowingVelocity` = `maxSpeed`

- Driving at `maxSpeed`. No stoplines, Obstacle approaching.
  ![image](https://user-images.githubusercontent.com/22786578/120652935-e4e8f200-c488-11eb-9909-945eabe40187.png)
  As the obstacle is approaching `egoFollowingVelocity` decreases. 
  - `egoStoppingVelocity` = `maxSpeed`
  - `egoFollowingVelocity` = `5`

- Driving at `maxSpeed`. Stopline approaching, Obstacle approaching. Stopline is closer.
  ![image](https://user-images.githubusercontent.com/22786578/120653167-1eb9f880-c489-11eb-9e8f-8a4d4b2bb276.png)
  As the obstacle is approaching `egoFollowingVelocity` decreases. 
  As the stopline is approaching `egoStoppingVelocity` decreases. The stopline is closer so `egoStoppingVelocity` < `egoFollowingVelocity`
  - `egoStoppingVelocity` = `3`
  - `egoFollowingVelocity` = `5`

- Driving at `maxSpeed`. Stopline approaching, Following obstacle. obstacle is closer.
  ![image](https://user-images.githubusercontent.com/22786578/120653734-a6a00280-c489-11eb-9293-a60e478255b5.png)
  As the obstacle is not approaching `egoFollowingVelocity` = `velocityOfNext`. 
  As the stopline is approaching `egoStoppingVelocity` decreases.
  - `egoStoppingVelocity` = `5`
  - `egoFollowingVelocity` = `velocityOfNext`

---

After those two values are computed we only need to select the smallest one to always make sure we will not miss a stopline or not stop for an obstacle. Those checks can be implemented in the `BehaviorStateMachine` to trigger state changes and also to lower lever check in the `DecisionMaker`.

---

This PR is not a full implementation and only includes the calculation of the values but bot logic related to them. So it is not functional. 
What's your opinion on this functionality ? If you think it's useful I can complete this PR.