### PR TITLE
Add a new hyper parameter to enable or disable the avoidance in the last section

### DIFF
--- a/op_planner/include/op_planner/RoadNetwork.h
+++ b/op_planner/include/op_planner/RoadNetwork.h
@@ -1273,6 +1273,7 @@ public:
 	bool 	enableTrafficLightBehavior;
 	bool 	enableStopSignBehavior;
 	bool 	enableTimeOutAvoidance;
+	bool 	enableFinalLocalPathUpdate;
 	double 	avoidanceTimeOut;
 
 	bool 	enabTrajectoryVelocities;
@@ -1319,6 +1320,7 @@ public:
 		enableLaneChange = false;
 		enableStopSignBehavior = false;
 		enabTrajectoryVelocities = false;
+		enableFinalLocalPathUpdate = true;
 		minIndicationDistance = 15;
 
 		enableTimeOutAvoidance = false;

--- a/op_planner/src/DecisionMaker.cpp
+++ b/op_planner/src/DecisionMaker.cpp
@@ -536,7 +536,7 @@ void DecisionMaker::InitBehaviorStates()
 
 	if((currIndex > index_limit
 			|| preCalcPrams->bRePlan
-			|| preCalcPrams->bNewGlobalPath) && !preCalcPrams->bFinalLocalTrajectory && m_iSinceLastReplan > m_params.nReliableCount)
+			|| preCalcPrams->bNewGlobalPath) && (!preCalcPrams->bFinalLocalTrajectory || m_params.enableFinalLocalPathUpdate) && m_iSinceLastReplan > m_params.nReliableCount)
 	{
 		m_iSinceLastReplan = 0;
 		return true;
@@ -558,7 +558,7 @@ void DecisionMaker::InitBehaviorStates()
 
 	if((currIndex > index_limit
 			|| preCalcPrams->bRePlan
-			|| preCalcPrams->bNewGlobalPath) && !preCalcPrams->bFinalLocalTrajectory && m_iSinceLastReplan > m_params.nReliableCount)
+			|| preCalcPrams->bNewGlobalPath) && (!preCalcPrams->bFinalLocalTrajectory || m_params.enableFinalLocalPathUpdate) && m_iSinceLastReplan > m_params.nReliableCount)
 	{
 		//Debug
 		//std::cout << "New Local Plan !! " << currIndex << ", "<< preCalcPrams->bRePlan << ", " << preCalcPrams->bNewGlobalPath  << ", " <<  m_TotalPath.at(0).size() << ", PrevLocal: " << m_Path.size();


### PR DESCRIPTION
Hello, the maintainers of OpenPlanner.

As discussed in https://github.com/hatem-darweesh/autoware.ai.openplanner/issues/9, replan is not triggered if the current rollouts reach the goal. Thus some collision will happen while there are obstacles between ego and goal. In some scenarios(such as bus stop), as you mentioned, this is a reasonable design choice. We enable and disable avoidance manually in the last section based on the hyper parameters, as suggested by your opinion. This approach provides convenience for users to adapt to various driving scenarios.

