### PR TITLE
Block rollouts that cut through undrivable area

### DIFF
--- a/op_planner/include/op_planner/MappingHelpers.h
+++ b/op_planner/include/op_planner/MappingHelpers.h
@@ -66,6 +66,7 @@ public:
 	static WayPoint* GetLastWaypoint(RoadNetwork& map);
 	static void FindAdjacentLanes(RoadNetwork& map);
 	static void FindAdjacentLanesV2(RoadNetwork& map, const double& min_d = 1.2, const double& max_d = 3.5);
+	static bool PointInMap(RoadNetwork& map,const WayPoint& pos);
 	/**
 	 *
 	 *

--- a/op_planner/include/op_planner/RoadNetwork.h
+++ b/op_planner/include/op_planner/RoadNetwork.h
@@ -1273,6 +1273,7 @@ public:
 	bool 	enableTrafficLightBehavior;
 	bool 	enableStopSignBehavior;
 	bool 	enableTimeOutAvoidance;
+	bool 	enableBlockingRolloutsOutOfMap;
 	double 	avoidanceTimeOut;
 
 	bool 	enabTrajectoryVelocities;
@@ -1319,6 +1320,7 @@ public:
 		enableLaneChange = false;
 		enableStopSignBehavior = false;
 		enabTrajectoryVelocities = false;
+		enableBlockingRolloutsOutOfMap = false;
 		minIndicationDistance = 15;
 
 		enableTimeOutAvoidance = false;

--- a/op_planner/include/op_planner/TrajectoryEvaluator.h
+++ b/op_planner/include/op_planner/TrajectoryEvaluator.h
@@ -7,6 +7,7 @@
 #define TRAJECTORY_EVALUATOR_H_
 
 #include "PlanningHelpers.h"
+#include "MappingHelpers.h"
 #include "PlannerCommonDef.h"
 
 namespace PlannerHNS
@@ -67,6 +68,7 @@ public:
   }
 
 public:
+  RoadNetwork m_Map;
   std::vector<WayPoint> all_contour_points_;
   std::vector<WayPoint> all_trajectories_points_;
   std::vector<WayPoint> collision_points_;
@@ -98,6 +100,8 @@ private:
   void initializeLocalRollOuts(const WayPoint& curr_state, const CAR_BASIC_INFO& car_info, const PlanningParams& params, const double& c_long_back_d, const std::vector<std::vector<WayPoint> >& original_roll_outs, std::vector<std::vector<WayPoint> >& local_roll_outs);
 
   void calculateDistanceCosts(const PlanningParams& params, const double& c_lateral_d, const std::vector<std::vector<WayPoint> >& roll_outs, const std::vector<WayPoint>& contour_points, const std::vector<WayPoint>& trajectory_points, std::vector<TrajectoryCost>& trajectory_costs, std::vector<WayPoint>& collision_points);
+
+  void blockTrajectoryOutOfRoad(const std::vector<std::vector<WayPoint> >& roll_outs, std::vector<TrajectoryCost>& trajectory_costs);
 
   TrajectoryCost findBestTrajectory(const PlanningParams& params, const int& prev_curr_index, const bool& b_keep_curr, std::vector<TrajectoryCost> trajectory_costs);
 

--- a/op_planner/include/op_planner/VectorMapLoader.h
+++ b/op_planner/include/op_planner/VectorMapLoader.h
@@ -21,7 +21,7 @@ namespace PlannerHNS {
 
 class VectorMapLoader {
 public:
-	VectorMapLoader(int map_version = 1, bool enable_lane_change = false, bool load_curb = false, bool load_lines = false, bool load_wayarea = false);
+	VectorMapLoader(int map_version = 1, bool enable_lane_change = false, bool load_curb = false, bool load_lines = false, bool load_wayarea = true);
 	virtual ~VectorMapLoader();
 
 	/**

--- a/op_planner/src/MappingHelpers.cpp
+++ b/op_planner/src/MappingHelpers.cpp
@@ -420,6 +420,18 @@ Lane* MappingHelpers::GetClosestLaneFromMap(const WayPoint& pos, RoadNetwork& ma
 	return pCloseLane;
 }
 
+bool MappingHelpers::PointInMap(RoadNetwork& map,const WayPoint& pos)
+{
+	for(unsigned int i=0; i < map.boundaries.size(); i++)
+	{
+		if ( PlanningHelpers::PointInsidePolygon(map.boundaries.at(i).points, pos) )
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
 WayPoint MappingHelpers::GetFirstWaypoint(RoadNetwork& map)
 {
 	for(unsigned int j=0; j< map.roadSegments.size(); j ++)

--- a/op_planner/src/PlanningHelpers.cpp
+++ b/op_planner/src/PlanningHelpers.cpp
@@ -3952,6 +3952,7 @@ void PlanningHelpers::InitializeSafetyPolygon(const PlannerHNS::WayPoint& curr_s
   car_border.points.push_back(top_left_car);
 }
 
+
 int PlanningHelpers::PointInsidePolygon(const std::vector<GPSPoint>& points,const GPSPoint& p)
 {
         int counter = 0;

--- a/op_planner/src/TrajectoryEvaluator.cpp
+++ b/op_planner/src/TrajectoryEvaluator.cpp
@@ -56,7 +56,7 @@ TrajectoryCost TrajectoryEvaluator::doOneStep(const std::vector<std::vector<WayP
 	best_trajectory.lane_index = 0;
 
 	if(roll_outs.size() == 0)
-	{
+        {
 		std::cout << " ### Zero generated rollouts, But They should = " << params.rollOutNumber + 1 << std::endl;
 		return best_trajectory;
 	}
@@ -87,6 +87,9 @@ TrajectoryCost TrajectoryEvaluator::doOneStep(const std::vector<std::vector<WayP
 
   collision_points_.clear();
   calculateDistanceCosts(params, critical_lateral_distance, local_roll_outs_, all_contour_points_, all_trajectories_points_, trajectory_costs_, collision_points_);
+  if(params.enableBlockingRolloutsOutOfMap == true){
+    blockTrajectoryOutOfRoad(local_roll_outs_, trajectory_costs_);
+  }
 //  collision_points_.clear();
 //  collision_points_.insert(collision_points_.begin(), all_contour_points_.begin(), all_contour_points_.end());
 //  collision_points_.insert(collision_points_.begin(), all_trajectories_points_.begin(), all_trajectories_points_.end());
@@ -360,6 +363,21 @@ void TrajectoryEvaluator::initializeCosts(const std::vector<std::vector<WayPoint
         tc.lane_change_cost = roll_outs.at(it).at(0).laneChangeCost;
       }
       trajectory_costs.push_back(tc);
+    }
+  }
+}
+
+void TrajectoryEvaluator::blockTrajectoryOutOfRoad(const std::vector<std::vector<WayPoint> >& roll_outs, std::vector<TrajectoryCost>& trajectory_costs)
+{
+  for(unsigned int i=0; i<roll_outs.size(); i++)
+  {
+    for(unsigned int j=0; j<roll_outs.at(i).size(); j++)
+    {
+      if( ! MappingHelpers::PointInMap(m_Map,roll_outs.at(i).at(j)) )
+      {
+        trajectory_costs.at(i).bBlocked = true;
+        break;
+      }
     }
   }
 }


### PR DESCRIPTION
Hello, maintainers of OpenPlanner.

As discussed in https://github.com/hatem-darweesh/autoware.ai.openplanner/issues/6, rollouts that cut through undrivable areas are not filtered out, leading the ego vehicle driving towards unexpected regions. This PR aims at solving this problem.

**The approach is described as follows:**
1. Enable load_wayarea in VectorMapLoader to load wayareas from wayarea.csv. 
2. In TrajectoryEvaluator::doOneStep, check every waypoint of every generated rollout to find if it is not inside the drivable area. If so, block the rollout.

**The approach is optional**. A parameter named `enableBlockingRolloutsOutOfMap` can be set `true` to enable this mechanism. 

**Note**: To fully implement this approach, I also send a PR to the `core_planning` repo, linked here: https://github.com/hatem-darweesh/core_planning/pull/18